### PR TITLE
Allow updating PDF producer metadata

### DIFF
--- a/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentInformation.cs
+++ b/src/foundation/src/PDFsharp/src/PdfSharp/Pdf/PdfDocumentInformation.cs
@@ -65,9 +65,13 @@ namespace PdfSharp.Pdf
         }
 
         /// <summary>
-        /// Gets the producer application (for example, PDFsharp).
+        /// Gets or sets the producer application (for example, PDFsharp).
         /// </summary>
-        public string Producer => Elements.GetString(Keys.Producer);
+        public string Producer
+        {
+            get => Elements.GetString(Keys.Producer);
+            set => Elements.SetString(Keys.Producer, value);
+        }
 
         /// <summary>
         /// Gets or sets the creation date of the document.


### PR DESCRIPTION
## Summary
- allow PdfDocumentInformation.Producer to be set

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop/targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b89d68dab08328891dd65f3ae34366